### PR TITLE
Add simple computer opponent

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div id='roundInfo' style='margin-top:8px;'></div>
   </div>
   <div class='player player2'>
-    <h2>Player 2</h2>
+    <h2>Computer</h2>
     <div class='coins' id='p2Coins'></div>
     <div class='coin-buttons'>
       <button id='p2Penny'><img src='images/penny.svg' alt='penny'></button>


### PR DESCRIPTION
## Summary
- rename second player area to **Computer**
- disable player controls for player 2
- implement a basic AI for player 2
- automatically trigger the computer turn after the human ends theirs

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_688400d402fc832296ecc848bbe60c44