### PR TITLE
Add animated coin flip modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,12 @@
   </div>
 </div>
 <div id='log'></div>
+<div id="modal" class="hidden">
+  <div class="modal-content">
+    <div id="modal-body"></div>
+    <button id="modal-ok" style="display:none">OK</button>
+  </div>
+</div>
 <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -8,6 +8,13 @@ body{font-family:Arial, sans-serif;margin:0;padding:0;}
 .coin-buttons button:enabled img{opacity:1;}
 button{margin:5px;padding:10px 15px;font-size:1rem;}
 #log{max-height:200px;overflow-y:auto;padding:10px;background:#f5f5f5;}
+#modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);display:none;align-items:center;justify-content:center;z-index:1000;}
+#modal.show{display:flex;}
+#modal .modal-content{background:#fff;padding:20px;border-radius:8px;text-align:center;max-width:90%;}
+#modal .coin{width:80px;height:80px;margin:10px;}
+#modal .result{font-size:1.2rem;margin-top:5px;}
+#modal .flipping{animation:flip 0.6s linear;}
+@keyframes flip{from{transform:rotateY(0);}to{transform:rotateY(720deg);}}
 @media(min-width:600px){
   .player1{order:0;}
   .center{flex:0 0 200px;order:1;}


### PR DESCRIPTION
## Summary
- add modal overlay and coin flip animations
- move end of round steal logic into animated modal interactions

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_688402dbf7b88322a75f7133cef379e3