### PR TITLE
Skip penny flip until 5¢

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Players alternate turns. On your turn, you must:
 - Once each player has played a turn this completes the round
 ### End of Round Steal
 
-Refer to this end of the round steal only once one of the players has at least 5¢ played. Otherwise skip this for now.
+Only perform this end-of-round steal once a player has at least 5¢ in play. If both players are below 5¢, skip any coin flips for that round.
 
 1. At the end of each round, coin flips determine if any player can steal from another player. Only use coins from the bank and return them once this is complete.
 2. Always end a round with this steal flipping, **even the supposed winning round** to determine if the winner actually wins.

--- a/script.js
+++ b/script.js
@@ -365,9 +365,7 @@ function countCoin(p,coinType){
 async function endOfRoundSteal(){
   const p1Total=players[0].total;
   const p2Total=players[1].total;
-  if(p1Total<5 && p2Total<5){
-    await pennyFlipModal();
-  }else{
+  if(p1Total>=5 || p2Total>=5){
     await highFlipModal();
   }
   checkVictory();


### PR DESCRIPTION
## Summary
- skip the early penny flip when both players have under 5¢
- update rules to explain that coin flips start once someone has 5¢

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840ba6ec10832289ea94e11a823c50