### PR TITLE
Improve computer nickel/dime strategy

### DIFF
--- a/script.js
+++ b/script.js
@@ -461,6 +461,17 @@ function chooseBestPlacement(idx){
   const myCounts=getCoinCounts(p);
   const oppCounts=getCoinCounts(opp);
   const allowed=['penny','nickel','dime','quarter'].filter(c=>coinDefs[c].value<=coinDefs[p.highest].value);
+
+  if(idx===computerIdx){
+    if(myCounts.dime===2 && myCounts.nickel===0 && allowed.includes('nickel') && allowed.includes('dime')){
+      const oppQuarters=oppCounts.quarter;
+      const myQuarters=myCounts.quarter;
+      if(oppQuarters-myQuarters===1){
+        return 'dime';
+      }
+      return 'nickel';
+    }
+  }
   let best=allowed[0];
   let bestScore=Infinity;
   for(const coin of allowed){


### PR DESCRIPTION
## Summary
- tweak computer strategy in `chooseBestPlacement`
- when the computer has two dimes and no nickel, and would tie the player's quarter count if it converted, it now plays another dime to try to steal a quarter
- otherwise it plays a nickel to set up a conversion

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6884190d68e8832293e6099a94c74a05