### PR TITLE
Auto-end turn when no conversion available

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,6 +96,9 @@ function placeCoin(idx,coin){
   p.placedThisTurn=true;
   updateHighest(p);
   render();
+  if(idx===0 && (!canConvert(p) || p.convertedThisTurn)){
+    setTimeout(() => endTurn(idx), 200);
+  }
 }
 
 function removeCoins(p,coinType,num){


### PR DESCRIPTION
## Summary
- auto-end the player's turn when they can't convert after placing a coin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68841ba067488322918e925133e966ba