### PR TITLE
Adjust steal flip order

### DIFF
--- a/script.js
+++ b/script.js
@@ -437,7 +437,17 @@ async function highFlipModal(){
     modalBody.appendChild(resDiv);
     showModal();
 
-    const order=['quarter','dime','nickel','penny'];
+    const baseOrder=['quarter','dime','nickel','penny'];
+    let startIdx=0;
+    while(startIdx<baseOrder.length){
+      const c=baseOrder[startIdx];
+      if(countCoin(players[0],c)>0 || countCoin(players[1],c)>0){
+        break;
+      }
+      startIdx++;
+    }
+    const order=baseOrder.slice(startIdx);
+
     let actionMsg='No steal this round.';
     for(const coin of order){
       img.src=coinDefs[coin].img;


### PR DESCRIPTION
## Summary
- only flip coins starting from the highest denomination present

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68841eb415608322b18610d071d307a1