### PR TITLE
Enable quarter conversion from pennies and dimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Players alternate turns. On your turn, you must:
         - **5 pennies** → **1 nickel**
         - **2 nickels** → **1 dime**
         - **1 nickel + 2 dimes** → **1 quarter**
+        - **5 pennies + 2 dimes** → **1 quarter**
     - After converting, place the new denomination coin as your new outermost coin and return any converted coins to the bank.
 - Throughout the game, your coins must be in ascending order from the prize outwards.
 - Once each player has played a turn this completes the round

--- a/script.js
+++ b/script.js
@@ -122,7 +122,10 @@ function updateHighest(p){
 function canConvert(p){
   const counts={penny:0,nickel:0,dime:0};
   p.coins.forEach(c=>{if(counts.hasOwnProperty(c)) counts[c]++;});
-  return counts.penny>=5 || counts.nickel>=2 || (counts.nickel>=1 && counts.dime>=2);
+  return counts.penny>=5 ||
+         counts.nickel>=2 ||
+         (counts.nickel>=1 && counts.dime>=2) ||
+         (counts.penny>=5 && counts.dime>=2);
 }
 
 async function convert(idx,strategic=true){
@@ -143,6 +146,9 @@ async function convert(idx,strategic=true){
   }
   if(counts.nickel>=1 && counts.dime>=2){
     options.push({from:{nickel:1,dime:2},to:'quarter'});
+  }
+  if(counts.penny>=5 && counts.dime>=2){
+    options.push({from:{penny:5,dime:2},to:'quarter'});
   }
   if(options.length===0) return;
 


### PR DESCRIPTION
## Summary
- allow converting 5 pennies and 2 dimes directly into a quarter
- document the new conversion option

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6884274c2d8c8322a84ea507d7806c98