### PR TITLE
Replace round info with Rules link

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <div class="navbar">
   <button id="newGameBtn">New Game</button>
   <div class="title">Dollar Prize</div>
-  <div id="roundInfo" class="round-info"></div>
+  <a id="roundInfo" class="round-info" href="https://www.adamgrant.info/dollar-prize" target="_blank">Rules</a>
 </div>
 <div class='game'>
   <div class='player player1'>

--- a/script.js
+++ b/script.js
@@ -83,8 +83,8 @@ function render(){
       }
     }
   });
-  const turnText=currentPlayer===0?"Your turn":"Computer's turn";
-  document.getElementById('roundInfo').textContent='Round '+round+' – '+turnText;
+  // The navbar now displays a static Rules link instead of the current round
+  // information, so we no longer update that element here.
 }
 
 function placeCoin(idx,coin){


### PR DESCRIPTION
## Summary
- show a Rules link in the navbar
- remove script logic that updated the round info

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884583cccf083228d683d67d9e29a78